### PR TITLE
Ensure Prerequisites are Installed

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -8,7 +8,10 @@
 
 - set_fact: grafana_release='grafana={{grafana_version}}'
 
+- name: grafana-install-prerequisites | Install Prerequisites
+  apt: name="apt-transport-https"
+
 - name: grafana-install | Install Grafana
-  apt: name="{{grafana_release}}"
+  apt: name="{{grafana_release}}" update_cache=true
   notify:
     - grafana restart


### PR DESCRIPTION
On a clean debian 8 install this role fails with the following error: 

```
TASK: [Stouts.grafana | grafana-install | Add debian repository pt. 2] ******** 
failed: [host] => {"failed": true, "parsed": false}

BECOME-SUCCESS-isablenvnjdwtrlajexbhpwxhawgrexd
Traceback (most recent call last):
  File "/home/swarman/.ansible/tmp/ansible-tmp-1459433200.08-118253439001662/apt_repository", line 2855, in <module>
    main()
  File "/home/swarman/.ansible/tmp/ansible-tmp-1459433200.08-118253439001662/apt_repository", line 464, in main
    cache.update()
  File "/usr/lib/python2.7/dist-packages/apt/cache.py", line 443, in update
    raise FetchFailedException(e)
apt.cache.FetchFailedException: E:The method driver /usr/lib/apt/methods/https could not be found.
Shared connection to x.x.x.x closed.

FATAL: all hosts have already failed -- aborting
```

This is due to the https transport not being installed by default AFAIK.

Additionally if an error is encountered adding the sources the role will never be able to complete until a manual apt-get update is run. As such it it's probably worth just doing the update first as part of the install.