### PR TITLE
Allow to install latest grafana release

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -11,7 +11,14 @@
 - name: grafana-install-prerequisites | Install Prerequisites
   apt: name="apt-transport-https"
 
-- name: grafana-install | Install Grafana
-  apt: name="{{grafana_release}}" update_cache=true
+- name: grafana-install | Install Grafana Release
+  apt: name="{{grafana_release}}"
+  when: grafana_version != "latest"
+  notify:
+    - grafana restart
+
+- name: grafana-install | Install Grafana Latest
+  apt: name="grafana"
+  when: grafana_version == "latest"
   notify:
     - grafana restart


### PR DESCRIPTION
Instead of explicitly specifying grafana version to be installed allow special value "latests" to install the latest package version.
