### PR TITLE
* plugin installation fixed

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -9,7 +9,8 @@
 
 - name: grafana-configure | Install plugins
   command: grafana-cli plugins install {{item}}
-  with_items: grafana_plugins_install
+  with_items: "{{grafana_plugins_install}}"
+#  when: grafana_plugins_install|length>0
   notify: grafana restart
 
 # - name: grafana-configure | Setup passlib

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -12,6 +12,6 @@
   apt: name="apt-transport-https"
 
 - name: grafana-install | Install Grafana
-  apt: name="{{grafana_release}}" update_cache=true
+  apt: name="{{grafana_release}}"
   notify:
   - grafana restart


### PR DESCRIPTION
Task `Install plugins` is always failing for me. It seems that variable name is mistyped.
Also I disabled cache, otherwise task `Install Grafana` isn't idempotent.

I've tested this on Ubuntu 16.04