### PR TITLE
fix debian install

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: grafana-install-prerequisites | Install Prerequisites
+  apt: name="apt-transport-https"
+
 - name: grafana-install | Add debian repository pt. 1
   apt_key: url='{{grafana_apt_key}}' id=D59097AB
 
@@ -7,9 +10,6 @@
   apt_repository: repo='{{grafana_apt_repository}}'
 
 - set_fact: grafana_release='grafana={{grafana_version}}'
-
-- name: grafana-install-prerequisites | Install Prerequisites
-  apt: name="apt-transport-https"
 
 - name: grafana-install | Install Grafana Release
   apt: name="{{grafana_release}}"


### PR DESCRIPTION
apt-transport-https seems to be required during grafana-install | Add debian repository pt. 2