### PR TITLE
+ allow to not setting grafana version

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -7,6 +7,7 @@
   apt_repository: repo='{{grafana_apt_repository}}'
 
 - set_fact: grafana_release='grafana={{grafana_version}}'
+  when: grafana_version != '*'
 
 - name: grafana-install-prerequisites | Install Prerequisites
   apt: name="apt-transport-https"
@@ -15,3 +16,10 @@
   apt: name="{{grafana_release}}"
   notify:
   - grafana restart
+  when: grafana_version != '*'
+
+- name: grafana-install | Install Grafana
+  apt: name="grafana" state=present
+  notify:
+  - grafana restart
+  when: grafana_version == '*'


### PR DESCRIPTION
If `grafana_version` is set to '*' then we don't require any specific version