### PR TITLE
Grafana package repository GPG key out of date

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Here is the list of all variables and their default values:
 
 ```yaml
 grafana_enabled: true                       # The role is enabled
-grafana_apt_repository: deb https://packagecloud.io/grafana/stable/debian/ jessie main
-grafana_apt_key: https://packagecloud.io/gpg.key
+grafana_apt_repository: deb https://packages.grafana.com/oss/deb stable main
+grafana_apt_key: https://packages.grafana.com/gpg.key
+grafana_apt_key_id: 24098CB6
 
 grafana_version: 3.1.1-*                    # Set version (set to latest to install latest version)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,9 @@
 ---
 
 grafana_enabled: true                       # The role is enabled
-grafana_apt_repository: deb https://packagecloud.io/grafana/stable/debian/ jessie main
-grafana_apt_key: https://packagecloud.io/gpg.key
+grafana_apt_repository: deb https://packages.grafana.com/oss/deb jessie main
+grafana_apt_key: https://packages.grafana.com/gpg.key
+grafana_apt_key_id: 24098CB6
 
 grafana_version: 4.1.2-*                      # Set version (set to latest to install latest version)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 grafana_enabled: true                       # The role is enabled
-grafana_apt_repository: deb https://packages.grafana.com/oss/deb jessie main
+grafana_apt_repository: deb https://packages.grafana.com/oss/deb stable main
 grafana_apt_key: https://packages.grafana.com/gpg.key
 grafana_apt_key_id: 24098CB6
 

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -4,7 +4,7 @@
   apt: name="apt-transport-https"
 
 - name: grafana-install | Add debian repository pt. 1
-  apt_key: url='{{grafana_apt_key}}' id=D59097AB
+  apt_key: url='{{grafana_apt_key}}' id='{{grafana_apt_key_id}}'
 
 - name: grafana-install | Add debian repository pt. 2
   apt_repository: repo='{{grafana_apt_repository}}'


### PR DESCRIPTION
Grafana package repository has been moved:
https://grafana.com/blog/2019/01/05/moving-to-packages.grafana.com/